### PR TITLE
Update minimum required CMake version to 3.13

### DIFF
--- a/lib/zlib/CMakeLists.txt
+++ b/lib/zlib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.13)
 set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS ON)
 
 project(zlib C)


### PR DESCRIPTION
This resolves the deprecation warning that CMake gives on configure. The main LevelDB CMakeLists.txt also uses 3.13.